### PR TITLE
Add update comment endpoint

### DIFF
--- a/server/src/routes/comments.js
+++ b/server/src/routes/comments.js
@@ -27,8 +27,8 @@ router.post('/', async (req, res) => {
 // eslint-disable-next-line no-unused-vars
 router.put('/:id', async (req, res) => {
   try {
-    if (req.body.body != null) {
-      await Comment.update({ _id: req.params.id }, { body: req.body.body });
+    if (req.body.commentBody != null) {
+      await Comment.update({ _id: req.params.id }, { body: req.body.commentBody });
       res.status(200).send();
     } else {
       res.status(400).json({ message: 'Please include a body to update this comment' });

--- a/server/src/routes/comments.js
+++ b/server/src/routes/comments.js
@@ -23,4 +23,19 @@ router.post('/', async (req, res) => {
   }
 });
 
+// Update one comment
+// eslint-disable-next-line no-unused-vars
+router.put('/:id', async (req, res) => {
+  try {
+    if (req.body.body != null) {
+      await Comment.update({ _id: req.params.id }, { body: req.body.body });
+      res.status(200).send();
+    } else {
+      res.status(400).json({ message: 'Please include a body to update this comment with' });
+    }
+  } catch (err) {
+    res.status(404).json({ message: err.message });
+  }
+});
+
 module.exports = router;

--- a/server/src/routes/comments.js
+++ b/server/src/routes/comments.js
@@ -31,7 +31,7 @@ router.put('/:id', async (req, res) => {
       await Comment.update({ _id: req.params.id }, { body: req.body.body });
       res.status(200).send();
     } else {
-      res.status(400).json({ message: 'Please include a body to update this comment with' });
+      res.status(400).json({ message: 'Please include a body to update this comment' });
     }
   } catch (err) {
     res.status(404).json({ message: err.message });


### PR DESCRIPTION
Fixes #132 

## Proposed Changes

  - Update backend to include an endpoint where a user can update their comment
  - Takes the comment ID and new body and updates the comment in the database

## To Do
Add an edit button on the frontend, like has been done for posts, to enable the updating of comments
