### PR TITLE
Add endpoint for deleting a comment

### DIFF
--- a/server/src/routes/comments.js
+++ b/server/src/routes/comments.js
@@ -39,29 +39,32 @@ router.put('/:id', async (req, res) => {
 });
 
 // Delete one comment
-// eslint-disable-next-line no-unused-vars
 router.delete('/:id', async (req, res) => {
   try {
     const comment = await Comment.findOne({
       _id: req.params.id,
     });
 
-    // Comment can be deleted entirely if it has no children.
-    // If it has children, the comment should be kept so that nested structure remains,
-    // so comment body is altered instead.
-    if (Object.keys(comment.children).length === 0) {
-      await Comment.findOneAndDelete({
-        _id: comment._id,
-      });
-
-      // Update parent to remove this comment as a child
-      await Post.update({ _id: comment.parentID }, { $pull: { children: comment._id } });
-      await Comment.update({ _id: comment.parentID }, { $pull: { children: comment._id } });
+    if (comment == null) {
+      res.status(400).json({ message: 'Comment not found. Please provide a valid comment ID' });
     } else {
-      await Comment.update({ _id: comment._id }, { body: '[Comment deleted]' });
-    }
+      // Comment can be deleted entirely if it has no children.
+      // If it has children, the comment should be kept so that nested structure remains,
+      // so comment body is altered instead.
+      if (Object.keys(comment.children).length === 0) {
+        await Comment.findOneAndDelete({
+          _id: comment._id,
+        });
 
-    res.status(200).send();
+        // Update parent to remove this comment as a child
+        await Post.update({ _id: comment.parentID }, { $pull: { children: comment._id } });
+        await Comment.update({ _id: comment.parentID }, { $pull: { children: comment._id } });
+      } else {
+        await Comment.update({ _id: comment._id }, { body: '[Comment deleted]' });
+      }
+
+      res.status(200).send();
+    }
   } catch (err) {
     res.status(404).json({ message: err.message });
   }

--- a/server/src/routes/comments.js
+++ b/server/src/routes/comments.js
@@ -46,7 +46,7 @@ router.delete('/:id', async (req, res) => {
     });
 
     if (comment == null) {
-      res.status(400).json({ message: 'Comment not found. Please provide a valid comment ID' });
+      res.status(404).json({ message: 'Comment not found. Please provide a valid comment ID' });
     } else {
       // Comment can be deleted entirely if it has no children.
       // If it has children, the comment should be kept so that nested structure remains,

--- a/server/src/routes/comments.js
+++ b/server/src/routes/comments.js
@@ -38,4 +38,28 @@ router.put('/:id', async (req, res) => {
   }
 });
 
+// Delete one comment
+// eslint-disable-next-line no-unused-vars
+router.delete('/:id', async (req, res) => {
+  try {
+    const comment = await Comment.findOne({
+      _id: req.params.id,
+    });
+
+    // Comment can be deleted entirely if it has no children.
+    // If it has children, the comment should be kept so that nested structure remains,
+    // so comment body is altered instead.
+    if (Object.keys(comment.children).length === 0) {
+      await Comment.findOneAndDelete({
+        _id: req.params.id,
+      });
+    } else {
+      await Comment.update({ _id: req.params.id }, { body: '[Comment deleted]' });
+    }
+    res.status(200).send();
+  } catch (err) {
+    res.status(404).json({ message: err.message });
+  }
+});
+
 module.exports = router;

--- a/server/src/routes/comments.js
+++ b/server/src/routes/comments.js
@@ -51,14 +51,14 @@ router.delete('/:id', async (req, res) => {
     // so comment body is altered instead.
     if (Object.keys(comment.children).length === 0) {
       await Comment.findOneAndDelete({
-        _id: req.params.id,
+        _id: comment._id,
       });
 
       // Update parent to remove this comment as a child
       await Post.update({ _id: comment.parentID }, { $pull: { children: comment._id } });
       await Comment.update({ _id: comment.parentID }, { $pull: { children: comment._id } });
     } else {
-      await Comment.update({ _id: req.params.id }, { body: '[Comment deleted]' });
+      await Comment.update({ _id: comment._id }, { body: '[Comment deleted]' });
     }
 
     res.status(200).send();

--- a/server/src/routes/comments.js
+++ b/server/src/routes/comments.js
@@ -53,9 +53,14 @@ router.delete('/:id', async (req, res) => {
       await Comment.findOneAndDelete({
         _id: req.params.id,
       });
+
+      // Update parent to remove this comment as a child
+      await Post.update({ _id: comment.parentID }, { $pull: { children: comment._id } });
+      await Comment.update({ _id: comment.parentID }, { $pull: { children: comment._id } });
     } else {
       await Comment.update({ _id: req.params.id }, { body: '[Comment deleted]' });
     }
+
     res.status(200).send();
   } catch (err) {
     res.status(404).json({ message: err.message });


### PR DESCRIPTION
Fixes #131 

## Proposed Changes

  - Add API endpoint to allow a user to delete their comment
  - Takes the comment ID and deletes the comment entirely if there are no children. If there are children, the comment's body is instead edited to "[Comment deleted]" to allow child comments to stay

## To Do

- Add a delete button on the frontend
- In future, lock this feature behind user authentication
