### PR TITLE
Add API call for deletePost

### DIFF
--- a/frontend/src/pages/Frontpage/Post.jsx
+++ b/frontend/src/pages/Frontpage/Post.jsx
@@ -13,8 +13,9 @@ import SadImg from '../../common/icons/sad.png';
 
 import styles from './Post.module.css';
 
-// Import for testing post updates
+// Import for testing post apis
 import updatePostService from '../../services/updatePostService';
+// import deletePostService from '../../services/deletePostService';
 
 const Post = ({
   id,
@@ -39,6 +40,12 @@ const Post = ({
     updatePostService(id, 'testTitle', 'testBody');
     loadPost();
   };
+
+  // Method used for testing post deletes
+  // const handleDelete = () => {
+  //   deletePostService(id);
+  //   loadPost();
+  // };
 
   return (
     <Card className={styles.root}>
@@ -111,6 +118,7 @@ const Post = ({
               startIcon={<EditIcon />}
               onClick={() => {
                 handleUpdate();
+                // handleDelete();
               }}
             >
               Edit

--- a/frontend/src/pages/Frontpage/Post.jsx
+++ b/frontend/src/pages/Frontpage/Post.jsx
@@ -13,6 +13,7 @@ import SadImg from '../../common/icons/sad.png';
 
 import styles from './Post.module.css';
 
+// Uncomment when delete post button is implemented
 // import deletePostService from '../../services/deletePostService';
 import EditPostModal from './EditPost/EditPostModal';
 import withUpdatePostService from './EditPost/withUpdatePostService';
@@ -28,10 +29,10 @@ const Post = ({ id, title, content, upvotes, downvotes, claps, handleVote, front
   const sadCount = downvotes + (upvoteSad ? 1 : 0);
   const [showModal, setModal] = useState(false);
 
-  // Method used for testing post deletes
+  // Call this method onClick of the delete button
   // const handleDelete = () => {
   //   deletePostService(id);
-  //   loadPost();
+  //   window.location.reload();
   // };
 
   return (

--- a/frontend/src/services/deletePostService.js
+++ b/frontend/src/services/deletePostService.js
@@ -1,0 +1,27 @@
+import { getPostRoute } from './apiRoutes';
+
+/* eslint-disable no-underscore-dangle */
+export class DeletePostError extends Error {}
+
+export default async id => {
+  const parameters = {
+    id,
+  };
+
+  const requestBody = JSON.stringify(parameters);
+
+  const response = await fetch(getPostRoute(id), {
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    method: 'DELETE',
+    body: requestBody,
+  });
+
+  if (!response.ok) {
+    const { message } = await response.json();
+    console.log(message);
+    throw new DeletePostError('Post does not exist');
+  }
+};

--- a/frontend/src/services/deletePostService.js
+++ b/frontend/src/services/deletePostService.js
@@ -21,6 +21,7 @@ export default async id => {
 
   if (!response.ok) {
     const { message } = await response.json();
+    // eslint-disable-next-line no-console
     console.log(message);
     throw new DeletePostError('Post does not exist');
   }


### PR DESCRIPTION
Fixes #121

## Proposed Changes

  - Added service to make an API call for deleting posts.
  - Added methods on Post.jsx for testing delete post without a button.

