### PR TITLE
Feature/add sub thread database

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -9,9 +9,11 @@ app.use(express.json());
 
 const postsRouter = require('./src/routes/posts');
 const commentsRouter = require('./src/routes/comments');
+const subThreadsRouter = require('./src/routes/subThreads');
 
 app.use('/api/posts', postsRouter);
 app.use('/api/comments', commentsRouter);
+app.use('/api/subThreads', subThreadsRouter);
 
 app.get('/', (req, res) => res.send('Hello World!'));
 

--- a/server/src/db/models/subThreads.js
+++ b/server/src/db/models/subThreads.js
@@ -1,0 +1,20 @@
+const mongoose = require('mongoose');
+
+const subThreadsSchema = new mongoose.Schema(
+  {
+    title: {
+      type: String,
+      required: true,
+      unique: true,
+    },
+    posts: {
+      type: Array,
+      default: [],
+    },
+  },
+  {
+    timestamps: { createdAt: 'date_created' },
+  },
+);
+
+module.exports = mongoose.model('SubThread', subThreadsSchema);

--- a/server/src/routes/posts.js
+++ b/server/src/routes/posts.js
@@ -3,6 +3,7 @@ const express = require('express');
 const router = express.Router();
 const Post = require('../db/models/post');
 const Comment = require('../db/models/comments');
+const SubThread = require('../db/models/subThreads');
 
 // Get all posts
 router.get('/', async (req, res) => {
@@ -54,7 +55,6 @@ const getNestedComments = async childrenIDs => {
 };
 
 // Get one post (detailed)
-// eslint-disable-next-line no-unused-vars
 router.get('/:id', async (req, res) => {
   try {
     const foundPost = await Post.findOne({ _id: req.params.id });
@@ -124,6 +124,21 @@ router.put('/:id/upvote', async (req, res) => {
       const returnPost = await Post.findById(req.body.id);
       res.status(200).json(returnPost);
     } else res.status(400).json({ message: 'Invalid upvote type' });
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+// Get all posts that belong to a specific subThread
+router.get('/subThread/:subThreadTitle', async (req, res) => {
+  try {
+    const foundSubThread = await SubThread.findOne({ title: req.params.subThreadTitle });
+    if (!foundSubThread) {
+      res.status(404).json({ message: 'This subThread does not exist' });
+      return;
+    }
+    const posts = await Post.find({ _id: { $in: foundSubThread.posts } });
+    res.send(posts);
   } catch (err) {
     res.status(400).json({ message: err.message });
   }

--- a/server/src/routes/subThreads.js
+++ b/server/src/routes/subThreads.js
@@ -1,0 +1,23 @@
+const express = require('express');
+
+const router = express.Router();
+const SubThread = require('../db/models/subThreads');
+
+// Initialise table with pre-defined subThreads until the add endpoint is connected.
+const initialisePromises = [
+  'SubThread1',
+  'SubThread2',
+  'SubThread3',
+  'SubThread4',
+  'SubThread5',
+].map(subThread => {
+  return SubThread.updateOne(
+    { title: subThread },
+    { $setOnInsert: { title: subThread, posts: [] } },
+    { upsert: true },
+  );
+});
+Promise.all(initialisePromises).catch();
+
+
+module.exports = router;

--- a/server/src/routes/subThreads.js
+++ b/server/src/routes/subThreads.js
@@ -19,6 +19,33 @@ const initialisePromises = [
 });
 Promise.all(initialisePromises).catch();
 
+// Create a new subThread
+router.post('/', async (req, res) => {
+  const { title } = req.body;
+
+  if (!title) {
+    res.status(400).json({ message: 'Please include a title' });
+    return;
+  }
+
+  try {
+    const existingSubThread = await SubThread.find({ title }).limit(1);
+    if (existingSubThread && Array.isArray(existingSubThread) && existingSubThread.length > 0) {
+      res.status(400).json({ message: 'This subThread already exists' });
+      return;
+    }
+
+    const subThread = new SubThread({
+      title,
+    });
+
+    const newSubThread = await subThread.save();
+    res.status(201).send(newSubThread);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
 // Get a list of all subThreads
 // eslint-disable-next-line no-unused-vars
 router.get('/', async (req, res) => {

--- a/server/src/routes/subThreads.js
+++ b/server/src/routes/subThreads.js
@@ -19,5 +19,11 @@ const initialisePromises = [
 });
 Promise.all(initialisePromises).catch();
 
+// Get a list of all subThreads
+// eslint-disable-next-line no-unused-vars
+router.get('/', async (req, res) => {
+  const subThreads = await SubThread.find({}, { title: 1 });
+  res.status(201).json(subThreads);
+});
 
 module.exports = router;


### PR DESCRIPTION
Fixes #156 

## Proposed Changes

  - Add a subThread schema
  - Initialise database with predefined sub-threads, until add sub-threads support is added to the frontend, blocked by #152 
  - Create an endpoint to get all sub-threads and add new sub-threads. Mounted at /app/subThreads.
 - Add endpoint to get all posts that belong to a subthread (based on name to future-proof for searching ability)
