### PR TITLE
Updated comment endpoints with user details

### DIFF
--- a/server/src/routes/comments.js
+++ b/server/src/routes/comments.js
@@ -66,7 +66,7 @@ router.put('/:id', firebaseAuthMiddleware, async (req, res) => {
     const user = await User.findOne({
       _id: comment.author,
     });
-    if (!req.body.commentBody) {
+    if (req.body.commentBody == null) {
       res.status(400).json({ message: 'Please include a body to update this comment' });
     } else if (user.email !== req.user.email) {
       res.status(403).json({ message: 'This comment can only be updated by its original author' });

--- a/server/src/routes/comments.js
+++ b/server/src/routes/comments.js
@@ -69,7 +69,7 @@ router.put('/:id', firebaseAuthMiddleware, async (req, res) => {
     if (req.body.commentBody == null) {
       res.status(400).json({ message: 'Please include a body to update this comment' });
     } else if (user.email !== req.user.email) {
-      res.status(403).json({ message: 'This comment can only be updated by the original author.' });
+      res.status(403).json({ message: 'This comment can only be updated by its original author' });
     } else {
       await Comment.update({ _id: req.params.id }, { body: req.body.commentBody });
       res.status(200).send();
@@ -92,7 +92,7 @@ router.delete('/:id', firebaseAuthMiddleware, async (req, res) => {
     if (comment == null) {
       res.status(404).json({ message: 'Comment not found. Please provide a valid comment ID' });
     } else if (user.email !== req.user.email) {
-      res.status(403).json({ message: 'This comment can only be deleted by the original author.' });
+      res.status(403).json({ message: 'This comment can only be deleted by its original author' });
     } else {
       // Comment can be deleted entirely if it has no children.
       // If it has children, the comment should be kept so that nested structure remains,

--- a/server/src/routes/comments.js
+++ b/server/src/routes/comments.js
@@ -100,14 +100,14 @@ router.delete('/:id', async (req, res) => {
     // so comment body is altered instead.
     if (Object.keys(comment.children).length === 0) {
       await Comment.findOneAndDelete({
-        _id: req.params.id,
+        _id: comment._id,
       });
 
       // Update parent to remove this comment as a child
       await Post.update({ _id: comment.parentID }, { $pull: { children: comment._id } });
       await Comment.update({ _id: comment.parentID }, { $pull: { children: comment._id } });
     } else {
-      await Comment.update({ _id: req.params.id }, { body: '[Comment deleted]' });
+      await Comment.update({ _id: comment._id }, { body: '[Comment deleted]' });
     }
 
     res.status(200).send();

--- a/server/src/routes/comments.js
+++ b/server/src/routes/comments.js
@@ -14,7 +14,7 @@ router.post('/', firebaseAuthMiddleware, async (req, res) => {
       email: req.user.email,
     });
 
-    if (user == null) {
+    if (!user) {
       user = new User({
         email: req.user.email,
       });
@@ -66,7 +66,7 @@ router.put('/:id', firebaseAuthMiddleware, async (req, res) => {
     const user = await User.findOne({
       _id: comment.author,
     });
-    if (req.body.commentBody == null) {
+    if (!req.body.commentBody) {
       res.status(400).json({ message: 'Please include a body to update this comment' });
     } else if (user.email !== req.user.email) {
       res.status(403).json({ message: 'This comment can only be updated by its original author' });
@@ -89,7 +89,7 @@ router.delete('/:id', firebaseAuthMiddleware, async (req, res) => {
       _id: comment.author,
     });
 
-    if (comment == null) {
+    if (!comment) {
       res.status(404).json({ message: 'Comment not found. Please provide a valid comment ID' });
     } else if (user.email !== req.user.email) {
       res.status(403).json({ message: 'This comment can only be deleted by its original author' });

--- a/server/src/routes/comments.js
+++ b/server/src/routes/comments.js
@@ -102,9 +102,14 @@ router.delete('/:id', async (req, res) => {
       await Comment.findOneAndDelete({
         _id: req.params.id,
       });
+
+      // Update parent to remove this comment as a child
+      await Post.update({ _id: comment.parentID }, { $pull: { children: comment._id } });
+      await Comment.update({ _id: comment.parentID }, { $pull: { children: comment._id } });
     } else {
       await Comment.update({ _id: req.params.id }, { body: '[Comment deleted]' });
     }
+
     res.status(200).send();
   } catch (err) {
     res.status(404).json({ message: err.message });

--- a/server/src/routes/comments.js
+++ b/server/src/routes/comments.js
@@ -87,4 +87,28 @@ router.delete('/:id', firebaseAuthMiddleware, async (req, res) => {
   }
 });
 
+// Delete one comment
+// eslint-disable-next-line no-unused-vars
+router.delete('/:id', async (req, res) => {
+  try {
+    const comment = await Comment.findOne({
+      _id: req.params.id,
+    });
+
+    // Comment can be deleted entirely if it has no children.
+    // If it has children, the comment should be kept so that nested structure remains,
+    // so comment body is altered instead.
+    if (Object.keys(comment.children).length === 0) {
+      await Comment.findOneAndDelete({
+        _id: req.params.id,
+      });
+    } else {
+      await Comment.update({ _id: req.params.id }, { body: '[Comment deleted]' });
+    }
+    res.status(200).send();
+  } catch (err) {
+    res.status(404).json({ message: err.message });
+  }
+});
+
 module.exports = router;

--- a/server/src/routes/comments.js
+++ b/server/src/routes/comments.js
@@ -95,7 +95,7 @@ router.delete('/:id', async (req, res) => {
     });
 
     if (comment == null) {
-      res.status(400).json({ message: 'Comment not found. Please provide a valid comment ID' });
+      res.status(404).json({ message: 'Comment not found. Please provide a valid comment ID' });
     } else {
       // Comment can be deleted entirely if it has no children.
       // If it has children, the comment should be kept so that nested structure remains,

--- a/server/test/integration/comment.spec.js
+++ b/server/test/integration/comment.spec.js
@@ -17,7 +17,10 @@ describe('Comments API', () => {
   });
 
   beforeEach(async done => {
-    middlewareStub.callsFake((req, res, next) => next());
+    middlewareStub.callsFake((req, res, next) => {
+      req.user = { email: 'test@test.com' };
+      next();
+    });
 
     // clear database after each test to remove any dependencies between tests
     db.drop()

--- a/server/test/integration/post.spec.js
+++ b/server/test/integration/post.spec.js
@@ -17,7 +17,10 @@ describe('Posts API', () => {
   });
 
   beforeEach(async done => {
-    middlewareStub.callsFake((req, res, next) => next());
+    middlewareStub.callsFake((req, res, next) => {
+      req.user = { email: 'test@test.com' };
+      next();
+    });
 
     // clear database after each test to remove any dependencies between tests
     db.drop()


### PR DESCRIPTION
Fixes #160 

## Proposed Changes

 - When adding a comment:
     - Checks if user already exists in db, otherwise adds new user to db
     - User is set as author of comment in db
     - Comment is added to user in db
 - When editing or deleting a comment:
     - Checks if the user attempting to edit the comment is the same as the user who made the comment
     - Only allows edit/delete if the user is the same
 - Updated tests to work with new changes
 - Also fixed typo in error message for comment get request