### PR TITLE
Feature/prevent vote abuse

### DIFF
--- a/server/src/routes/posts.js
+++ b/server/src/routes/posts.js
@@ -123,38 +123,42 @@ router.delete('/:id', firebaseAuthMiddleware, async (req, res) => {
 
 // Upvote a post
 router.put('/:id/upvote', firebaseAuthMiddleware, async (req, res) => {
-  const currentPost = await Post.findById(req.body.id);
+  const currentPost = await Post.findById(req.params.id);
+
+  if (currentPost == null) {
+    res.status(400).json({ message: 'Invalid post ID' });
+  }
 
   try {
     if (req.body.upvote_type === 'clap') {
       const claps = currentPost.upvotes_clap;
 
       await Post.updateOne(
-        { _id: req.body.id },
-        { upvotes_clap: claps + (req.body.upvote === true ? 1 : -1) },
+        { _id: req.params.id },
+        { upvotes_clap: claps + (req.body.upvote == true ? 1 : -1) },
       );
 
-      const returnPost = await Post.findById(req.body.id);
+      const returnPost = await Post.findById(req.params.id);
       res.status(200).json(returnPost);
     } else if (req.body.upvote_type === 'laugh') {
       const laughs = currentPost.upvotes_laugh;
 
       await Post.update(
-        { _id: req.body.id },
-        { upvotes_laugh: laughs + (req.body.upvote === true ? 1 : -1) },
+        { _id: req.params.id },
+        { upvotes_laugh: laughs + (req.body.upvote == true ? 1 : -1) },
       );
 
-      const returnPost = await Post.findById(req.body.id);
+      const returnPost = await Post.findById(req.params.id);
       res.status(200).json(returnPost);
     } else if (req.body.upvote_type === 'sad') {
       const sads = currentPost.upvotes_sad;
 
       await Post.update(
-        { _id: req.body.id },
-        { upvotes_sad: sads + (req.body.upvote === true ? 1 : -1) },
+        { _id: req.params.id },
+        { upvotes_sad: sads + (req.body.upvote == true ? 1 : -1) },
       );
 
-      const returnPost = await Post.findById(req.body.id);
+      const returnPost = await Post.findById(req.params.id);
       res.status(200).json(returnPost);
     } else res.status(400).json({ message: 'Invalid upvote type' });
   } catch (err) {

--- a/server/src/routes/posts.js
+++ b/server/src/routes/posts.js
@@ -159,12 +159,12 @@ router.put('/:id/upvote', firebaseAuthMiddleware, async (req, res) => {
 
     if (!checkClap && !checkLaugh && !checkSad) {
       // If no current vote
-      if (req.body.upvote === 'true') {
+      if (req.body.upvote === true) {
         updateFlag = true;
       } else {
         updateFlag = false;
       }
-    } else if (req.body.upvote === 'false') {
+    } else if (req.body.upvote === false) {
       // Remove current vote, dont set update flag
       if (checkClap) {
         await Post.updateOne({ _id: req.params.id }, { upvotes_clap: claps - 1 });
@@ -210,14 +210,14 @@ router.put('/:id/upvote', firebaseAuthMiddleware, async (req, res) => {
       );
     } else if (updateFlag && req.body.upvote_type === 'laugh') {
       // Laugh Upvote
-      await Post.update({ _id: req.params.id }, { upvotes_laugh: laughs + 1 });
+      await Post.updateOne({ _id: req.params.id }, { upvotes_laugh: laughs + 1 });
       await User.updateOne(
         { _id: currentUser._id },
         { $addToSet: { 'votes.laughs': req.params.id } },
       );
     } else if (updateFlag && req.body.upvote_type === 'sad') {
       // Sad Upvote
-      await Post.update({ _id: req.params.id }, { upvotes_sad: sads + 1 });
+      await Post.updateOne({ _id: req.params.id }, { upvotes_sad: sads + 1 });
       await User.updateOne(
         { _id: currentUser._id },
         { $addToSet: { 'votes.sads': req.params.id } },

--- a/server/src/routes/posts.js
+++ b/server/src/routes/posts.js
@@ -127,118 +127,106 @@ router.put('/:id/upvote', firebaseAuthMiddleware, async (req, res) => {
   const currentPost = await Post.findById(req.params.id);
   const currentUser = await User.findOne({ email: req.user.email });
 
-  //Check body inputs are valid
+  // Check body inputs are valid
   if (currentPost == null) {
     res.status(400).json({ message: 'Invalid post ID' });
+    return;
   }
   if (currentUser == null) {
     res.status(400).json({ message: 'Invalid user ID' });
+    return;
   }
-  if (req.body.upvote_type != 'clap' && req.body.upvote_type != 'laugh' && req.body.upvote_type != 'sad') {
+  if (
+    req.body.upvote_type !== 'clap' &&
+    req.body.upvote_type !== 'laugh' &&
+    req.body.upvote_type !== 'sad'
+  ) {
     res.status(400).json({ message: 'Invalid vote type' });
+    return;
   }
 
   try {
-    //Check if user has already voted on this post
+    // Check if user has already voted on this post
     const checkClap = currentUser.votes.claps.includes(req.params.id);
     const checkLaugh = currentUser.votes.laughs.includes(req.params.id);
     const checkSad = currentUser.votes.sads.includes(req.params.id);
 
-    var updateFlag = false;
+    let updateFlag = false;
 
-    //Current vote values
+    // Current vote values
     const claps = currentPost.upvotes_clap;
     const laughs = currentPost.upvotes_laugh;
     const sads = currentPost.upvotes_sad;
 
-
-    if (!checkClap && !checkLaugh && !checkSad){
-    //If no current vote
-      updateFlag = true;
+    if (!checkClap && !checkLaugh && !checkSad) {
+      // If no current vote
+      if (req.body.upvote === 'true') {
+        updateFlag = true;
+      } else {
+        updateFlag = false;
+      }
+    } else if (req.body.upvote === 'false') {
+      if (checkClap) {
+        await Post.updateOne({ _id: req.params.id }, { upvotes_clap: claps - 1 });
+        await User.updateOne({ _id: currentUser._id }, { $pull: { 'votes.claps': req.params.id } });
+      } else if (checkLaugh) {
+        await Post.updateOne({ _id: req.params.id }, { upvotes_laugh: laughs - 1 });
+        await User.updateOne(
+          { _id: currentUser._id },
+          { $pull: { 'votes.laughs': req.params.id } },
+        );
+      } else if (checkSad) {
+        await Post.updateOne({ _id: req.params.id }, { upvotes_sad: sads - 1 });
+        await User.updateOne({ _id: currentUser._id }, { $pull: { 'votes.sads': req.params.id } });
+      }
     } else if (checkClap && req.body.upvote_type !== 'clap') {
-    //Remove clap & set update flag
-      await Post.updateOne(
-        { _id: req.params.id },
-        { upvotes_clap: claps - 1 },
-      );
-      await User.updateOne(
-        { _id: currentUser._id },
-        { $pull: { "votes.claps": req.params.id } }
-      );
+      // Remove clap & set update flag
+      await Post.updateOne({ _id: req.params.id }, { upvotes_clap: claps - 1 });
+      await User.updateOne({ _id: currentUser._id }, { $pull: { 'votes.claps': req.params.id } });
       updateFlag = true;
-
-    }  else if (checkLaugh && req.body.upvote_type !== 'laugh') {
-    //Remove laugh & set update flag
-      await Post.updateOne(
-        { _id: req.params.id },
-        { upvotes_laugh: laughs - 1 },
-      );
-      await User.updateOne(
-        { _id: currentUser._id },
-        { $pull: { "votes.laughs": req.params.id } }
-      )
+    } else if (checkLaugh && req.body.upvote_type !== 'laugh') {
+      // Remove laugh & set update flag
+      await Post.updateOne({ _id: req.params.id }, { upvotes_laugh: laughs - 1 });
+      await User.updateOne({ _id: currentUser._id }, { $pull: { 'votes.laughs': req.params.id } });
       updateFlag = true;
-
     } else if (checkSad && req.body.upvote_type !== 'sad') {
-    //Remove sad & set update flag
-      await Post.updateOne(
-        { _id: req.params.id },
-        { upvotes_sad: sads - 1 },
-      );
-      await User.updateOne(
-        { _id: currentUser._id },
-        { $pull: { "votes.sads": req.params.id } }
-      )
+      // Remove sad & set update flag
+      await Post.updateOne({ _id: req.params.id }, { upvotes_sad: sads - 1 });
+      await User.updateOne({ _id: currentUser._id }, { $pull: { 'votes.sads': req.params.id } });
       updateFlag = true;
-
     } else {
-    //No change needed
+      // No change needed
       const returnPost = await Post.findById(req.params.id);
       res.status(200).json(returnPost);
+      return;
     }
 
     if (updateFlag && req.body.upvote_type === 'clap') {
-      await Post.updateOne(
-        { _id: req.params.id },
-        { upvotes_clap: claps + (req.body.upvote == true ? 1 : -1) },
-      );
+      await Post.updateOne({ _id: req.params.id }, { upvotes_clap: claps + 1 });
 
       await User.updateOne(
         { _id: currentUser._id },
-        { $addToSet: { "votes.claps": req.params.id } }
-      )
-
-      const returnPost = await Post.findById(req.params.id);
-      res.status(200).json(returnPost);
-
+        { $addToSet: { 'votes.claps': req.params.id } },
+      );
     } else if (updateFlag && req.body.upvote_type === 'laugh') {
-      await Post.update(
-        { _id: req.params.id },
-        { upvotes_laugh: laughs + (req.body.upvote == true ? 1 : -1) },
-      );
+      await Post.update({ _id: req.params.id }, { upvotes_laugh: laughs + 1 });
 
       await User.updateOne(
         { _id: currentUser._id },
-        { $addToSet: { "votes.laughs": req.params.id } }
-      )
-
-      const returnPost = await Post.findById(req.params.id);
-      res.status(200).json(returnPost);
-
+        { $addToSet: { 'votes.laughs': req.params.id } },
+      );
     } else if (updateFlag && req.body.upvote_type === 'sad') {
-      await Post.update(
-        { _id: req.params.id },
-        { upvotes_sad: sads + (req.body.upvote == true ? 1 : -1) },
-      );
+      await Post.update({ _id: req.params.id }, { upvotes_sad: sads + 1 });
 
       await User.updateOne(
         { _id: currentUser._id },
-        { $addToSet: { "votes.sads": req.params.id } }
-      )
-
-      const returnPost = await Post.findById(req.params.id);
-      res.status(200).json(returnPost);
+        { $addToSet: { 'votes.sads': req.params.id } },
+      );
     }
+
+    const returnPost = await Post.findById(req.params.id);
+    res.status(200).json(returnPost);
+    return;
   } catch (err) {
     res.status(400).json({ message: err.message });
   }

--- a/server/src/routes/posts.js
+++ b/server/src/routes/posts.js
@@ -125,7 +125,7 @@ router.delete('/:id', firebaseAuthMiddleware, async (req, res) => {
 // Upvote a post
 router.put('/:id/upvote', firebaseAuthMiddleware, async (req, res) => {
   const currentPost = await Post.findById(req.params.id);
-  const currentUser = await User.findById(req.body.user);
+  const currentUser = await User.findOne({ email: req.user.email });
 
   //Check body inputs are valid
   if (currentPost == null) {
@@ -162,7 +162,7 @@ router.put('/:id/upvote', firebaseAuthMiddleware, async (req, res) => {
         { upvotes_clap: claps - 1 },
       );
       await User.updateOne(
-        { _id: req.body.user },
+        { _id: currentUser._id },
         { $pull: { "votes.claps": req.params.id } }
       );
       updateFlag = true;
@@ -174,7 +174,7 @@ router.put('/:id/upvote', firebaseAuthMiddleware, async (req, res) => {
         { upvotes_laugh: laughs - 1 },
       );
       await User.updateOne(
-        { _id: req.body.user },
+        { _id: currentUser._id },
         { $pull: { "votes.laughs": req.params.id } }
       )
       updateFlag = true;
@@ -186,7 +186,7 @@ router.put('/:id/upvote', firebaseAuthMiddleware, async (req, res) => {
         { upvotes_sad: sads - 1 },
       );
       await User.updateOne(
-        { _id: req.body.user },
+        { _id: currentUser._id },
         { $pull: { "votes.sads": req.params.id } }
       )
       updateFlag = true;
@@ -204,7 +204,7 @@ router.put('/:id/upvote', firebaseAuthMiddleware, async (req, res) => {
       );
 
       await User.updateOne(
-        { _id: req.body.user },
+        { _id: currentUser._id },
         { $addToSet: { "votes.claps": req.params.id } }
       )
 
@@ -218,7 +218,7 @@ router.put('/:id/upvote', firebaseAuthMiddleware, async (req, res) => {
       );
 
       await User.updateOne(
-        { _id: req.body.user },
+        { _id: currentUser._id },
         { $addToSet: { "votes.laughs": req.params.id } }
       )
 
@@ -232,7 +232,7 @@ router.put('/:id/upvote', firebaseAuthMiddleware, async (req, res) => {
       );
 
       await User.updateOne(
-        { _id: req.body.user },
+        { _id: currentUser._id },
         { $addToSet: { "votes.sads": req.params.id } }
       )
 

--- a/server/src/routes/posts.js
+++ b/server/src/routes/posts.js
@@ -143,9 +143,6 @@ router.put('/:id/upvote', firebaseAuthMiddleware, async (req, res) => {
     res.status(400).json({ message: 'Invalid vote type' });
     return;
   }
-  if (req.body.upvote_type != 'clap' && req.body.upvote_type != 'laugh' && req.body.upvote_type != 'sad') {
-    res.status(400).json({ message: 'Invalid vote type' });
-  }
 
   try {
     // Check if user has already voted on this post
@@ -168,7 +165,7 @@ router.put('/:id/upvote', firebaseAuthMiddleware, async (req, res) => {
         updateFlag = false;
       }
     } else if (req.body.upvote === 'false') {
-      //Remove current vote, dont set update flag
+      // Remove current vote, dont set update flag
       if (checkClap) {
         await Post.updateOne({ _id: req.params.id }, { upvotes_clap: claps - 1 });
         await User.updateOne({ _id: currentUser._id }, { $pull: { 'votes.claps': req.params.id } });
@@ -204,25 +201,22 @@ router.put('/:id/upvote', firebaseAuthMiddleware, async (req, res) => {
       return;
     }
 
-
     if (updateFlag && req.body.upvote_type === 'clap') {
-      //Clap upvote
+      // Clap upvote
       await Post.updateOne({ _id: req.params.id }, { upvotes_clap: claps + 1 });
       await User.updateOne(
         { _id: currentUser._id },
         { $addToSet: { 'votes.claps': req.params.id } },
       );
-
     } else if (updateFlag && req.body.upvote_type === 'laugh') {
-      //Laugh Upvote
+      // Laugh Upvote
       await Post.update({ _id: req.params.id }, { upvotes_laugh: laughs + 1 });
       await User.updateOne(
         { _id: currentUser._id },
         { $addToSet: { 'votes.laughs': req.params.id } },
       );
-
     } else if (updateFlag && req.body.upvote_type === 'sad') {
-      //Sad Upvote
+      // Sad Upvote
       await Post.update({ _id: req.params.id }, { upvotes_sad: sads + 1 });
       await User.updateOne(
         { _id: currentUser._id },

--- a/server/src/routes/posts.js
+++ b/server/src/routes/posts.js
@@ -169,6 +169,7 @@ router.put('/:id/upvote', firebaseAuthMiddleware, async (req, res) => {
         updateFlag = false;
       }
     } else if (req.body.upvote === 'false') {
+      //Remove current vote, dont set update flag
       if (checkClap) {
         await Post.updateOne({ _id: req.params.id }, { upvotes_clap: claps - 1 });
         await User.updateOne({ _id: currentUser._id }, { $pull: { 'votes.claps': req.params.id } });
@@ -204,23 +205,26 @@ router.put('/:id/upvote', firebaseAuthMiddleware, async (req, res) => {
       return;
     }
 
-    if (updateFlag && req.body.upvote_type === 'clap') {
-      await Post.updateOne({ _id: req.params.id }, { upvotes_clap: claps + 1 });
 
+    if (updateFlag && req.body.upvote_type === 'clap') {
+      //Clap upvote
+      await Post.updateOne({ _id: req.params.id }, { upvotes_clap: claps + 1 });
       await User.updateOne(
         { _id: currentUser._id },
         { $addToSet: { 'votes.claps': req.params.id } },
       );
-    } else if (updateFlag && req.body.upvote_type === 'laugh') {
-      await Post.update({ _id: req.params.id }, { upvotes_laugh: laughs + 1 });
 
+    } else if (updateFlag && req.body.upvote_type === 'laugh') {
+      //Laugh Upvote
+      await Post.update({ _id: req.params.id }, { upvotes_laugh: laughs + 1 });
       await User.updateOne(
         { _id: currentUser._id },
         { $addToSet: { 'votes.laughs': req.params.id } },
       );
-    } else if (updateFlag && req.body.upvote_type === 'sad') {
-      await Post.update({ _id: req.params.id }, { upvotes_sad: sads + 1 });
 
+    } else if (updateFlag && req.body.upvote_type === 'sad') {
+      //Sad Upvote
+      await Post.update({ _id: req.params.id }, { upvotes_sad: sads + 1 });
       await User.updateOne(
         { _id: currentUser._id },
         { $addToSet: { 'votes.sads': req.params.id } },

--- a/server/src/routes/posts.js
+++ b/server/src/routes/posts.js
@@ -144,6 +144,9 @@ router.put('/:id/upvote', firebaseAuthMiddleware, async (req, res) => {
     res.status(400).json({ message: 'Invalid vote type' });
     return;
   }
+  if (req.body.upvote_type != 'clap' && req.body.upvote_type != 'laugh' && req.body.upvote_type != 'sad') {
+    res.status(400).json({ message: 'Invalid vote type' });
+  }
 
   try {
     // Check if user has already voted on this post

--- a/server/src/routes/posts.js
+++ b/server/src/routes/posts.js
@@ -6,7 +6,6 @@ const User = require('../db/models/users');
 const Post = require('../db/models/post');
 const Comment = require('../db/models/comments');
 const SubThread = require('../db/models/subThreads');
-const User = require('../db/models/users');
 
 // Get all posts
 router.get('/', async (req, res) => {

--- a/server/src/routes/posts.js
+++ b/server/src/routes/posts.js
@@ -6,6 +6,7 @@ const User = require('../db/models/users');
 const Post = require('../db/models/post');
 const Comment = require('../db/models/comments');
 const SubThread = require('../db/models/subThreads');
+const User = require('../db/models/users');
 
 // Get all posts
 router.get('/', async (req, res) => {
@@ -124,9 +125,14 @@ router.delete('/:id', firebaseAuthMiddleware, async (req, res) => {
 // Upvote a post
 router.put('/:id/upvote', firebaseAuthMiddleware, async (req, res) => {
   const currentPost = await Post.findById(req.params.id);
+  const user = await User.findById(req.body.user);
 
+  //Check body inputs are valid
   if (currentPost == null) {
     res.status(400).json({ message: 'Invalid post ID' });
+  }
+  if (user == null) {
+    res.status(400).json({ message: 'Invalid user ID' });
   }
 
   try {

--- a/server/test/integration/post.spec.js
+++ b/server/test/integration/post.spec.js
@@ -563,6 +563,25 @@ describe('Posts API', () => {
     const response2 = await supertest(app).get('/api/posts');
     const testId = response2.body[0]._id;
 
+    const upvoteRequest1 = {
+      id: testId,
+      upvote_type: 'clap',
+      upvote: true,
+    };
+
+    const response4 = await supertest(app)
+      .put(`/api/posts/${testId}/upvote`)
+      .send(upvoteRequest1);
+    expect(response4.status).toBe(200);
+
+    expect(response4.body._id).toBe(testId);
+    expect(response4.body.title).toBe(postData.title);
+    expect(response4.body.body).toBe(postData.body);
+    expect(response4.body.date_created).toBeDefined();
+    expect(response4.body.upvotes_clap).toBe(1);
+    expect(response4.body.upvotes_laugh).toBe(0);
+    expect(response4.body.upvotes_sad).toBe(0);
+
     // Upvote the post
     const upvoteRequest = {
       id: testId,
@@ -579,7 +598,7 @@ describe('Posts API', () => {
     expect(response3.body.title).toBe(postData.title);
     expect(response3.body.body).toBe(postData.body);
     expect(response3.body.date_created).toBeDefined();
-    expect(response3.body.upvotes_clap).toBe(-1);
+    expect(response3.body.upvotes_clap).toBe(0);
     expect(response3.body.upvotes_laugh).toBe(0);
     expect(response3.body.upvotes_sad).toBe(0);
     done();
@@ -657,7 +676,7 @@ describe('Posts API', () => {
     done();
   });
 
-  it('downvote post successfully', async done => {
+  it('remove vote successfully', async done => {
     // create post
     const postData = {
       title: 'Test post',
@@ -677,12 +696,32 @@ describe('Posts API', () => {
     const upvoteRequest = {
       id: testId,
       upvote_type: 'laugh',
+      upvote: true,
+    };
+
+    const response4 = await supertest(app)
+      .put(`/api/posts/${testId}/upvote`)
+      .send(upvoteRequest);
+    expect(response4.status).toBe(200);
+
+    expect(response4.body._id).toBe(testId);
+    expect(response4.body.title).toBe(postData.title);
+    expect(response4.body.body).toBe(postData.body);
+    expect(response4.body.date_created).toBeDefined();
+    expect(response4.body.upvotes_clap).toBe(0);
+    expect(response4.body.upvotes_laugh).toBe(1);
+    expect(response4.body.upvotes_sad).toBe(0);
+
+    // Downvote the post
+    const upvoteRequest1 = {
+      id: testId,
+      upvote_type: 'laugh',
       upvote: false,
     };
 
     const response3 = await supertest(app)
       .put(`/api/posts/${testId}/upvote`)
-      .send(upvoteRequest);
+      .send(upvoteRequest1);
     expect(response3.status).toBe(200);
 
     expect(response3.body._id).toBe(testId);
@@ -690,7 +729,7 @@ describe('Posts API', () => {
     expect(response3.body.body).toBe(postData.body);
     expect(response3.body.date_created).toBeDefined();
     expect(response3.body.upvotes_clap).toBe(0);
-    expect(response3.body.upvotes_laugh).toBe(-1);
+    expect(response3.body.upvotes_laugh).toBe(0);
     expect(response3.body.upvotes_sad).toBe(0);
     done();
   });
@@ -750,6 +789,25 @@ describe('Posts API', () => {
     const response2 = await supertest(app).get('/api/posts');
     const testId = response2.body[0]._id;
 
+    const upvoteRequest1 = {
+      id: testId,
+      upvote_type: 'sad',
+      upvote: true,
+    };
+
+    const response4 = await supertest(app)
+      .put(`/api/posts/${testId}/upvote`)
+      .send(upvoteRequest1);
+    expect(response4.status).toBe(200);
+
+    expect(response4.body._id).toBe(testId);
+    expect(response4.body.title).toBe(postData.title);
+    expect(response4.body.body).toBe(postData.body);
+    expect(response4.body.date_created).toBeDefined();
+    expect(response4.body.upvotes_clap).toBe(0);
+    expect(response4.body.upvotes_laugh).toBe(0);
+    expect(response4.body.upvotes_sad).toBe(1);
+
     // Upvote the post
     const upvoteRequest = {
       id: testId,
@@ -768,7 +826,7 @@ describe('Posts API', () => {
     expect(response3.body.date_created).toBeDefined();
     expect(response3.body.upvotes_clap).toBe(0);
     expect(response3.body.upvotes_laugh).toBe(0);
-    expect(response3.body.upvotes_sad).toBe(-1);
+    expect(response3.body.upvotes_sad).toBe(0);
     done();
   });
 });


### PR DESCRIPTION
Fixes #116 

## Proposed Changes
- Voting endpoint now uses middleware authentication
- User db now stores which posts a user has voted on
- Users can only cast one vote at a time, if the endpoint is called after they have already voted, their initial vote is removed and a new one is cast
- "upvote" : "false" will now delete their vote regardless of "upvote_type"
