### PR TITLE
hide edit and delete button for anonymous user

### DIFF
--- a/frontend/src/pages/Frontpage/Post.jsx
+++ b/frontend/src/pages/Frontpage/Post.jsx
@@ -103,6 +103,41 @@ const Post = ({
   //   window.location.reload();
   // };
 
+  const handleButtonsShow = () => {
+    if (!document.cookie) return null;
+    const storedPostTypes = JSON.parse(localStorage.getItem('firebaseui::rememberedAccounts'));
+    if (!storedPostTypes) return null;
+
+    return (
+      <>
+        <div className={styles['post-edit-button']}>
+          <Button
+            variant="contained"
+            size="small"
+            startIcon={<EditIcon />}
+            onClick={() => {
+              setModal(true);
+            }}
+          >
+            Edit
+          </Button>
+        </div>
+        <div className={styles['post-delete-button']}>
+          <Button
+            variant="contained"
+            size="small"
+            startIcon={<DeleteIcon />}
+            onClick={() => {
+              setDeleteModal(true);
+            }}
+          >
+            Delete
+          </Button>
+        </div>
+      </>
+    );
+  };
+
   return (
     <Card className={styles.root}>
       <div className={styles['post-box']}>
@@ -167,30 +202,7 @@ const Post = ({
               {content}
             </Typography>
           </div>
-          <div className={styles['post-edit-button']}>
-            <Button
-              variant="contained"
-              size="small"
-              startIcon={<EditIcon />}
-              onClick={() => {
-                setModal(true);
-              }}
-            >
-              Edit
-            </Button>
-          </div>
-          <div className={styles['post-delete-button']}>
-            <Button
-              variant="contained"
-              size="small"
-              startIcon={<DeleteIcon />}
-              onClick={() => {
-                setDeleteModal(true);
-              }}
-            >
-              Delete
-            </Button>
-          </div>
+          {handleButtonsShow()}
         </CardContent>
       </div>
       {title && (


### PR DESCRIPTION

### Is your feature request related to a problem? Please describe.
As a developer, I would like to ensure that only signed-in users can delete a post.
As a developer, I would like to ensure that only signed-in users can edit a post.

### Describe the solution you'd like
At the moment, any anonymous individual can delete a post. However, if we wish to catalog the posts, it would be much easier to have the posts linked to a user's account. In addition, it will prevent anonymous individuals from deleting posts without any restrictions. Thus, it would be beneficial to ensure that only signed-in users can delete posts.

At the moment, any anonymous individual can edit a post. However, if we wish to catalog the posts, it would be much easier to have the posts linked to a user's account. In addition, it will prevent anonymous individuals from editing posts without any restrictions. Thus, it would be beneficial to ensure that only signed-in users can edit posts.

## Proposed Changes
  - Hide edit button for an anonymous user
  - Hide delete button for an anonymous user

![b1e78f1f12d978049732a3227723968](https://user-images.githubusercontent.com/49338344/80378304-9285eb00-88f0-11ea-8dec-23b35223a453.png)
![c53aafea75a4765f3b29844a2b13fd8](https://user-images.githubusercontent.com/49338344/80378310-9580db80-88f0-11ea-94ac-0155603b9176.png)



Fixes #185 
Fixes #186 
